### PR TITLE
Update versions and streamline the build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,18 @@
-FROM python:3.6-alpine
+FROM python:3.6.7-alpine3.8 AS base
 
-RUN apk add --no-cache bash
+# install python dependencies
+FROM base AS builder
 
-RUN pip install --upgrade pip; pip install -U awscli awsebcli
+COPY requirements.txt /
+RUN pip install --upgrade pip==18.1 && \
+   pip install --install-option="--prefix=/install" -r /requirements.txt
 
-RUN adduser -D -u 500 aws
+# build final image
+FROM base
+
+COPY --from=builder /install /usr/local
+RUN apk add --no-cache bash=4.4.19-r1
+ARG UID=1000
+RUN adduser -D -u $UID aws
 USER aws
 WORKDIR /home/aws

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Runs AWS commands using docker container
 
 For example:
 
-In order to deploy UI on your current UI repository that has UI built in `dist` folderyou can run the following command that mounts your current directory to `/home/aws/src` and sync's it with the S3 bucket of your choice.  The mounted `dist` folder is at `/home/aws/src/dist` in your container.
+In order to deploy UI on your current UI repository that has UI built in `dist` folder you can run the following command that mounts your current directory to `/home/aws/src` and sync's it with the S3 bucket of your choice.  The mounted `dist` folder is at `/home/aws/src/dist` in your container.
 
 ```sh
 docker run --rm --name aws_sync -v `pwd`:/home/aws/src -v ~/.aws:/home/aws/.aws academicmerit/awscli:latest aws --profile amerit-nuevo s3 sync /home/aws/src/dist/ s3://ui-metadata-import.staging.academicmerit.com
@@ -11,13 +11,11 @@ docker run --rm --name aws_sync -v `pwd`:/home/aws/src -v ~/.aws:/home/aws/.aws 
 
 ## Build and Push
 
+Build images and push to Docker hub:
 ```sh
-$ docker build -t academicmerit/awscli .
-$ docker images     # check the image has been built in your local repository
-$ docker push academicmerit/awscli:latest
+bin/build
 ```
 
 ## Note on different tags
-- awscli:ec2 tag is used to run on bastion host and it uses uid 500 for aws user inside docker container
-- awscli:latest or awscli:macos tag is used to run on local dev environmnet and uses uid 1000 for aws user inside docker container
-  - this is necessary for mounted volume to be writeable on MacOS when running [bin/init](https://github.com/academicmerit/service-fym/blob/dev/bin/init) redacted db refresh script
+- awscli:ec2 tag is used to run on bastion host. It uses uid 500 for aws user inside docker container.
+- awscli:latest or awscli:macos tag is used to run on local dev environment. It uses uid 1000 for aws user inside docker container. This is necessary for mounted volume to be writeable on MacOS when running [bin/init](https://github.com/academicmerit/service-fym/blob/dev/bin/init) redacted db refresh script.

--- a/bin/build
+++ b/bin/build
@@ -1,2 +1,12 @@
-docker build -t academicmerit/awscli:$1 .
-docker push academicmerit/awscli:$1
+#!/bin/bash
+
+# build for ec2
+docker build --build-arg UID=500 -t academicmerit/awscli:ec2 .
+
+# build for macos
+docker build -t academicmerit/awscli:macos -t academicmerit/awscli:latest .
+
+# push to repo
+for TAG in latest macos ec2; do
+   docker push academicmerit/awscli:$TAG
+done

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+awscli==1.16.60
+awsebcli==3.14.6
+s3cmd==2.0.2


### PR DESCRIPTION
* update and pin versions of the base image, Bash, AWS CLI, and other python dependencies.
* add s3cmd as a potentially useful utility.
* use a multistage build to save 20-30 MB in the final image.
* set the UID as a build-time argument, to simplify changing this value for different builds.
* update the build script to build and push all tags.